### PR TITLE
Fix links in chapters to the source code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # next.js build output
 .next
+
+# IntelliJ idea meta data
+.idea

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `docs/` directory is required by GitHub pages, on which the site is hosted.
    ```
    $ npm run console
 
-   > fp_book_club_ts@0.0.1 console ~/src/fp_book_club_ts
+   > fp_book_club_ts@0.0.1 console ~/code/fp_book_club_ts
    > ts-node
 
    > console.log("Hi there!");
@@ -39,13 +39,13 @@ The `docs/` directory is required by GitHub pages, on which the site is hosted.
    ```
    $ npm test
 
-   > fp_book_club_ts@0.0.1 test ~/src/fp_book_club_ts
+   > fp_book_club_ts@0.0.1 test ~/code/fp_book_club_ts
    > jest
 
-    PASS  fpbookclub/intro/cafe.test.ts
+    PASS  libfpts/intro/cafe.test.ts
      ✓ returns a Coffee (51ms)
 
-     console.log fpbookclub/intro/impure_example.ts:13
+     console.log libfpts/intro/impure_example.ts:13
        Side effect! Charging the credit card...
 
    Test Suites: 1 passed, 1 total

--- a/site/src/chapter_1.md
+++ b/site/src/chapter_1.md
@@ -13,7 +13,7 @@ A function has a side effect if it does anything other than return a value. Exam
 We'll walk through refactoring a simple program to remove side effects and demonstrate some TypeScript syntax. We'll
 also touch on two import concepts in functional programming: *referential transparency* and the *substitution model*.
 
-See [the code repository](https://github.com/calebharris/fp_book_club_ts/tree/master/fpbookclub/intro) for expanded,
+See [the code repository](https://github.com/calebharris/fp_book_club_ts/tree/master/code/libfpts/intro) for expanded,
 runnable versions of these examples.
 
 ### A program with side effects

--- a/site/src/chapter_2.md
+++ b/site/src/chapter_2.md
@@ -7,7 +7,7 @@ using higher-order functions (HOFs), and writing polymorphic HOFs.
 
 ## Introducing TypeScript: an example
 
-<<< @/fpbookclub/getting_started/abs.ts
+<<< @/../code/libfpts/getting_started/abs.ts
 
 The building blocks of TypeScript programs are modules. For now, it's fine to think of each TypeScript file as though
 it automatically defines a module. The `export` keyword does not come into play in this example, but makes the `abs`
@@ -87,17 +87,17 @@ occur. In that case, it works kind of like an implicit `main` method. But if we 
 
 ## Running our program
 
-The easist way to run this and other programs in these notes is to clone the [Git repository][fpbookclub_repo] and
+The easiest way to run this and other programs in these notes is to clone the [Git repository][fpbookclub_repo] and
 follow the instructions in the README. You'll use npm, a standard package-management tool in the Node.js ecosystem, to
 download this project's dependencies, build it, and run it.
 
 Once you've completed those steps, you can run the program we've been discussing using the console script:
 
 ```
-$ npm run console -- fpbookclub/getting_started/abs.ts
+$ npm run console -- libfpts/getting_started/abs.ts
 
 > fp_book_club_ts@0.0.1 console /Users/caleb/fp_book_club_ts
-> ts-node "fpbookclub/getting_started/abs.ts"
+> ts-node "libfpts/getting_started/abs.ts"
 
 The absolute value of -42 is 42
 ```
@@ -112,7 +112,7 @@ $ npm run console
 > fp_book_club_ts@0.0.1 console /Users/caleb/src/fp_book_club_ts
 > ts-node
 
-> import { abs } from "./fpbookclub/getting_started/abs";
+> import { abs } from "./code/libfpts/getting_started/abs";
 {}
 > abs(-13);
 The absolute value of -42 is 42
@@ -137,18 +137,18 @@ $ npm test
 > fp_book_club_ts@0.0.1 test /Users/caleb/src/fp_book_club_ts
 > jest
 
- PASS  fpbookclub/getting_started/abs.test.ts
+ PASS  libfpts/getting_started/abs.test.ts
   ● Console
 
-    console.log fpbookclub/getting_started/abs.ts:32
+    console.log libfpts/getting_started/abs.ts:32
       The absolute value of -42 is 42
 
- PASS  fpbookclub/intro/cafe.test.ts
+ PASS  libfpts/intro/cafe.test.ts
   ● Console
 
-    console.log fpbookclub/intro/impure_example.ts:13
+    console.log libfpts/intro/impure_example.ts:13
       Side effect! Charging the credit card...
-    console.log fpbookclub/intro/cafe.test.ts:35
+    console.log libfpts/intro/cafe.test.ts:35
       Another side effect
 
 
@@ -166,10 +166,10 @@ watch session.
 ```
 $ npm run test:watch
 
- PASS  fpbookclub/getting_started/abs.test.ts
+ PASS  libfpts/getting_started/abs.test.ts
   ✓ abs computes the absolute value of a number (4ms)
 
-  console.log fpbookclub/getting_started/abs.ts:32
+  console.log libfpts/getting_started/abs.ts:32
     The absolute value of -42 is 42
 
 Test Suites: 1 passed, 1 total
@@ -274,7 +274,7 @@ function factorial(n: number): number {
 
 ::: tip Note
 You can find expanded code for this and the following examples in the code repo at
-[/fpbookclub/getting_started/math.ts][repo_gs].
+[/code/libfpts/getting_started/math.ts][repo_gs].
 :::
 
 We write loops functionally, without mutating a loop variable, with *recursive* functions. The variable `go` holds a
@@ -637,7 +637,7 @@ In the above example, `charge.combine(charge)` is using the method syntax. We *c
 
 ```
 > charge.combine.call({}, charge);
-/Users/caleb/src/fp_book_club_ts/fpbookclub/intro/pure_example.ts:32
+/Users/caleb/src/fp_book_club_ts/code/libfpts/intro/pure_example.ts:32
             throw new Error("Can't combine charges to different cards");
             ...
 ```
@@ -746,7 +746,7 @@ Next up... functional data structures, starting with lists.
 [fpbookclub_repo]: https://github.com/calebharris/fp_book_club_ts "Functional Programming in TypeScript on GitHub"
 [jest]: https://jestjs.io/en/ "Jest"
 [mdn_arw]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions "Arrow functions - MDN"
-[repo_gs]: https://github.com/calebharris/fp_book_club_ts/tree/master/fpbookclub/getting_started "Getting started - Functional Programming in TypeScript on GitHub"
+[repo_gs]: https://github.com/calebharris/fp_book_club_ts/tree/master/code/libfpts/getting_started "Getting started - Functional Programming in TypeScript on GitHub"
 [wikip_fib]: https://en.wikipedia.org/wiki/Fibonacci_number "Fibonacci number - Wikipedia"
 [wikip_para]: https://en.wikipedia.org/wiki/Parametric_polymorphism "Parametric polymorphism - Wikipedia"
 [wikip_subt]: https://en.wikipedia.org/wiki/Subtyping "Subtyping - Wikipedia"

--- a/site/src/chapter_3.md
+++ b/site/src/chapter_3.md
@@ -342,7 +342,7 @@ And now... some exercises for manipulating lists.
 
 ::: tip Note
 As we complete these exercises, we'll be creating a reusable `List` module. You can find the code for `List` in the code
-repo at [/fpbookclub/data_structures/list.ts][repo_list].
+repo at [/code/libfpts/data_structures/list.ts][repo_list].
 :::
 
 ### Exercise 3.2. `getTail`
@@ -1166,6 +1166,6 @@ while adhering to functional principals. In other words, without exceptions.
 [ch_1_chg]: chapter_1.html#adding-a-payments-object "Chapter 1 - Functional Programming in TypeScript"
 [fpscala_notes_3]: https://github.com/fpinscala/fpinscala/wiki/Chapter-3:-Functional-data-structures "Chapter 3 -
 fpinscala/fpinscala Wiki"
-[repo_list]: https://github.com/calebharris/fp_book_club_ts/blob/master/fpbookclub/data_structures/list.ts "List - Functional Programming in TypeScript"
+[repo_list]: https://github.com/calebharris/fp_book_club_ts/blob/master/code/libfpts/data_structures/list.ts "List - Functional Programming in TypeScript"
 [scala_vector]: https://www.scala-lang.org/api/current/scala/collection/immutable/Vector.html "Vector - Scala Standard Library"
 [wikip_cat]: https://en.wikipedia.org/wiki/Category_theory "Category theory - Wikipedia"

--- a/site/src/chapter_5.md
+++ b/site/src/chapter_5.md
@@ -109,7 +109,7 @@ const memoize = <A>(f: () => A): () => A => {
 Now if we refactor `maybeTwice` to use `memoize`, we can see that it only executes the thunk once.
 
 ``` typescript
-> import util from "./fpbookclub/getting_started/util";
+> import util from "./code/libfpts/getting_started/util";
 {}
 > const maybeTwice = (b: boolean, i: () => number) => {
 ... const i2 = util.memoize(i);


### PR DESCRIPTION
Hi Caleb,

the split into `code` and `site` (https://github.com/calebharris/fp_book_club_ts/commit/fcc49a54f0c1c5a8c65c2cf0f7fec47077d63fab) broke the links from the chapters to the source code and I took the liberty of fixing them.