### PR TITLE
Not legal TypeScript syntax

### DIFF
--- a/site/src/chapter_2.md
+++ b/site/src/chapter_2.md
@@ -419,7 +419,7 @@ and which function to call to obtain the result. We can factor these differences
 function, `formatResult`, that's more general:
 
 ```typescript
-function formatResult(name: string, x: number, f: number => number) {
+function formatResult(name: string, x: number, f: (n: number) => number) {
   return `The ${name} of ${x} is ${f(x)}`;
 }
 ```


### PR DESCRIPTION
The parameter list (for a lambda) must include a variable name.

Quoting from typescriptlang.org: 
https://www.typescriptlang.org/docs/handbook/functions.html
"A function’s type has the same two parts: the type of the arguments and the return type. When writing out the whole function type, both parts are required. We write out the parameter types just like a parameter list, giving each parameter a name and a type. This name is just to help with readability."